### PR TITLE
add moderation and article restoration workflow

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ArticlesController < Admin::BaseController
-  before_action :set_article, only: [:destroy, :resolve_reports, :dismiss_reports]
+  before_action :set_article, only: [:destroy, :resolve_reports, :dismiss_reports, :new_hide, :hide, :approve_restoration, :new_rejection, :reject_restoration ]
   def destroy
     @article.reports.pending.update_all(status: :resolved)
     @article.discard
@@ -13,9 +13,71 @@ class Admin::ArticlesController < Admin::BaseController
     @article.reports.pending.update_all(status: :dismissed)
     redirect_to admin_moderation_path, notice: "Reports for article were dismissed."
   end
+  def new_hide
+    authorize @article, :hide?
+    respond_to do |format|
+      format.turbo_stream
+      format.html {
+        render turbo_stream: turbo_stream.replace(@article) {
+          render partial: "admin/moderations/hide_article_row", article: @article
+        }
+      }
+    end
+  end
+  def new_rejection
+    authorize @article, :hide?
+    respond_to do |format|
+      format.turbo_stream
+      format.html {
+        render turbo_stream: turbo_stream.replace(@article) {
+          render partial: "admin/moderations/reject_form_row", article: @article
+        }
+      }
+    end
+  end
+
+  def hide
+    authorize @article, :hide?
+    @article.reports.pending.update_all(status: :resolved)
+    @article.discard
+    record = @article.moderation_records.create!(
+      admin: current_user,
+      admin_reason: params.dig(:article, :admin_reason),
+      status: :hidden
+    )
+    AuthorNotifierJob.perform_async(record.id, "hidden")
+    redirect_to admin_moderation_path, notice: "Article has been hidden."
+  end
+  def approve_restoration
+    authorize @article, :restore?
+    if (record = @article.moderation_records.pending_review.last)
+      record.update(status: :approved)
+      @article.undiscard
+      @article.reports.pending.update_all(status: :resolved)
+      AuthorNotifierJob.perform_async(record.id, "approved")
+      redirect_to admin_moderation_path, notice: "Article restored and request approved."
+    else
+      redirect_to admin_moderation_path, alert: "Could not find a pending request."
+    end
+  end
+  def reject_restoration
+    authorize @article, :hide?
+    if (record = @article.moderation_records.pending_review.last)
+      record.update(status: :rejected, rejection_reason: params.dig(:article, :rejection_reason))
+      AuthorNotifierJob.perform_async(record.id, "rejected")
+      redirect_to admin_moderation_path, notice: "Restoration request was rejected."
+    else
+      redirect_to admin_moderation_path, alert: "Could not find a pending request."
+    end
+  end
 
   private
   def set_article
-    @article = Article.kept.friendly.find(params[:id])
+    scope = if action_name.in?(%w[hide new_hide approve_restoration new_rejection reject_restoration])
+              Article.all
+    else
+              Article.kept
+    end
+    @article = scope.friendly.find(params[:id])
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,5 +1,4 @@
 class Admin::DashboardController < Admin::BaseController
-  # before_action :require_admin
   def index
     # Overview Cards Data
     @total_users = User.count
@@ -11,18 +10,18 @@ class Admin::DashboardController < Admin::BaseController
     @articles_per_week = Article.group_by_week(:created_at).count
     # Moderation Queue (10 most recent pending reports)
     # @pending_reports = Report.pending.includes(:user, reportable: [:user]).order(created_at: :desc).limit(10)
-    @pending_reports = Report.pending
-                             .where("(reportable_type = 'Article' AND reportable_id IN (?)) OR (reportable_type = 'Comment' AND reportable_id IN (?))",
-                               Article.kept.select(:id),
-                               Comment.kept.select(:id)
-                             )
-                             .includes(:user)
-                             .order(created_at: :desc)
-                             .limit(10)
-
+    reported_article_ids = Report.pending.where(reportable_type: 'Article').pluck(:reportable_id)
+    review_article_ids = ModerationRecord.pending_review.pluck(:article_id)
+    all_article_ids = (reported_article_ids + review_article_ids).uniq
+    reported_comment_ids = Report.pending.where(reportable_type: 'Comment').pluck(:reportable_id)
+    @actionable_articles = Article.with_discarded.where(id: all_article_ids)
+                                  .includes(:user).order(updated_at: :desc).limit(5)
+    @actionable_comments = Comment.with_discarded.where(id: reported_comment_ids)
+                                  .includes(:user, :article).order(updated_at: :desc).limit(5)
+    @actionable_items = (@actionable_articles + @actionable_comments)
+                          .sort_by(&:updated_at).reverse.first(10)
     # Spotlight Section
     @most_clapped_articles = Article.order(claps_count: :desc).limit(3)
     @most_commented_articles = Article.order(comments_count: :desc).limit(3)
-
   end
 end

--- a/app/controllers/admin/moderations_controller.rb
+++ b/app/controllers/admin/moderations_controller.rb
@@ -3,12 +3,14 @@ class Admin::ModerationsController < Admin::BaseController
     @scope = params[:scope] || "articles"
 
     if @scope == "articles"
-      @results = Article.kept.joins(:reports)
-                        .where(reports: { status: :pending })
-                        .distinct
-                        .includes(:user, reports: [:user])
-                        .order(created_at: :desc)
-      @pagy, @results = pagy(@results, items: 10)
+      reported_ids = Report.pending.where(reportable_type: 'Article').pluck(:reportable_id)
+      review_ids = ModerationRecord.pending_review.pluck(:article_id)
+      all_ids = (reported_ids + review_ids).uniq
+
+      scope = Article.with_discarded.where(id: all_ids)
+                     .includes(:user, reports: [:user], moderation_records: [:admin])
+                     .order(updated_at: :desc)
+      @pagy, @results = pagy(scope)
     elsif @scope == "comments"
       @results = Comment.kept.joins(:reports)
                         .where(reports: { status: :pending })

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
                                  items: 5, page_param: :kept_page)
     @pagy_discarded, @discarded_articles = pagy(@user.articles.discarded.order(discarded_at: :desc),
                                                 items: 5, page_param: :discarded_page)
+
   end
   def edit
     authorize @user

--- a/app/mailers/author_notification_mailer.rb
+++ b/app/mailers/author_notification_mailer.rb
@@ -1,0 +1,18 @@
+class AuthorNotificationMailer < ApplicationMailer
+  def article_hidden(record)
+    send_notification(record, "An update on your article: #{record.article.title}")
+  end
+  def request_approved(record)
+    send_notification(record, "Your article has been restored!")
+  end
+  def request_rejected(record)
+    send_notification(record, "An update on your article restoration request")
+  end
+  private
+  def send_notification(record, subject)
+    @record  = record
+    @article = record.article
+    @user    = @article.user
+    mail(to: @user.email, subject: subject)
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,6 +3,7 @@ class Article < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: [:slugged, :history]
   attr_writer :topic_name
+  attr_accessor :author_note
 
   validates :topic, presence: true
   validates :title, presence: true
@@ -16,6 +17,7 @@ class Article < ApplicationRecord
   has_many :clapped_users, through: :claps, source: :user
   has_many :comments, dependent: :destroy
   has_many :reports, as: :reportable, dependent: :destroy
+  has_many :moderation_records, dependent: :destroy
   belongs_to :topic
   belongs_to :user
 

--- a/app/models/moderation_record.rb
+++ b/app/models/moderation_record.rb
@@ -1,0 +1,5 @@
+class ModerationRecord < ApplicationRecord
+  belongs_to :article
+  belongs_to :admin, class_name: "User"
+  enum :status, { hidden: 0, pending_review: 1, approved: 2, rejected: 3 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ApplicationRecord
   has_many :clapped_articles, through: :claps, source: :article
   has_many :comments, dependent: :destroy
   has_many :reports, dependent: :destroy
+  has_many :moderation_actions, class_name: "ModerationRecord", foreign_key: "admin_id", dependent: :nullify
   after_discard do
     articles.find_each(&:discard)
     comments.find_each(&:discard)

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -1,6 +1,6 @@
 class ArticlePolicy < ApplicationPolicy
   def show?
-    true
+    record.kept? || (user.present? && (user.admin? || record.user == user))
   end
   def create?
     user.present?
@@ -22,7 +22,12 @@ class ArticlePolicy < ApplicationPolicy
   end
   class Scope < Scope
     def resolve
-      scope.all
+      if user&.admin?
+        scope.with_discarded
+      else
+        scope.kept
+      end
+
     end
   end
 end

--- a/app/sidekiq/author_notifier_job.rb
+++ b/app/sidekiq/author_notifier_job.rb
@@ -1,0 +1,16 @@
+class AuthorNotifierJob
+  include Sidekiq::Job
+
+  def perform(moderation_record_id, action)
+    record = ModerationRecord.find_by(id: moderation_record_id)
+    return unless record
+    case action.to_s
+    when "hidden"
+      AuthorNotificationMailer.article_hidden(record).deliver_now
+    when "approved"
+      AuthorNotificationMailer.request_approved(record).deliver_now
+    when "rejected"
+      AuthorNotificationMailer.request_rejected(record).deliver_now
+    end
+  end
+end

--- a/app/sidekiq/reset_mailer_job.rb
+++ b/app/sidekiq/reset_mailer_job.rb
@@ -3,7 +3,6 @@ class ResetMailerJob
 
   def perform(user_id,token)
     user = User.find(user_id)
-    puts "abcde #{token}"
     UserMailer.password_reset(user,token).deliver_now
   end
 end

--- a/app/views/admin/articles/new_hide.turbo_stream.erb
+++ b/app/views/admin/articles/new_hide.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace(@article) do %>
+  <%= render "admin/moderations/hide_article_row", article: @article %>
+<% end %>

--- a/app/views/admin/articles/new_rejection.turbo_stream.erb
+++ b/app/views/admin/articles/new_rejection.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace(@article) do %>
+  <%= render "admin/moderations/reject_form_row", article: @article %>
+<% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -33,26 +33,58 @@
 
   <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
     <div class="bg-white p-6 rounded-lg shadow-md border border-gray-200">
-      <h3 class="text-lg font-medium text-gray-900 mb-4">Quick Moderation Queue</h3>
+      <div class="flex justify-between items-center mb-4">
+        <h3 class="text-lg font-medium text-gray-900">Quick Moderation Queue</h3>
+        <%= link_to "View All", admin_moderation_path, class: "text-sm font-medium text-indigo-600 hover:underline" %>
+      </div>
       <div class="flow-root">
-        <% if @pending_reports.any? %>
+        <% if @actionable_items.any? %>
           <ul role="list" class="-my-5 divide-y divide-gray-200">
-            <% @pending_reports.each do |report| %>
+            <% @actionable_items.each do |item| %>
               <li class="py-4">
                 <div class="flex items-center space-x-4">
                   <div class="flex-1 min-w-0">
+
+                    <%# --- Logic to determine item type and status --- %>
+                    <% is_article = item.is_a?(Article) %>
+                    <% is_review_request = is_article && item.moderation_records.any?(&:pending_review?) %>
+
+                    <%# --- Display Title and Link --- %>
                     <p class="text-sm font-medium text-gray-900 truncate">
-                      <% if report.reportable.is_a?(Article) %>
-                        Article: <%= link_to report.reportable.title, article_path(report.reportable), class: "text-blue-600 hover:underline" %>
+                      <% if is_article %>
+                        Article: <%= link_to item.title, admin_moderation_path(scope: 'articles'), class: "text-blue-600 hover:underline" %>
                       <% else %>
-                        Comment on: <%= link_to report.reportable.article.title, article_path(report.reportable.article), class: "text-blue-600 hover:underline" %>
+                        Comment on: <%= link_to item.article.title, admin_moderation_path(scope: 'comments'), class: "text-blue-600 hover:underline" %>
                       <% end %>
                     </p>
-                    <p class="text-sm text-gray-500 truncate italic">"<%= report.reason %>"</p>
-                    <p class="text-xs text-gray-400">Reported by <%= report.user.name %> <%= time_ago_in_words(report.created_at) %> ago</p>
+
+                    <%# --- Display Reason/Note --- %>
+                    <p class="text-sm text-gray-500 truncate italic">
+                      <% if is_review_request %>
+                        Author's Note: "<%= item.moderation_records.pending_review.last.author_note %>"
+                      <% else %>
+                        "<%= truncate(item.reports.pending.last.reason, length: 70) %>"
+                      <% end %>
+                    </p>
+
+                    <%# --- Display Actor and Timestamp --- %>
+                    <p class="text-xs text-gray-400">
+                      <% if is_review_request %>
+                        Requested by <%= item.user.name %>
+                      <% else %>
+                        Reported by <%= item.reports.pending.last.user.name %>
+                      <% end %>
+                      <%= time_ago_in_words(item.updated_at) %> ago
+                    </p>
                   </div>
+
+                  <%# --- Display Status Badge --- %>
                   <div>
-                    <span class="inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-red-100 bg-red-600 rounded">PENDING</span>
+                    <% if is_review_request %>
+                      <span class="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10">Awaiting Review</span>
+                    <% else %>
+                      <span class="inline-flex items-center rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-inset ring-red-700/10">Reported</span>
+                    <% end %>
                   </div>
                 </div>
               </li>
@@ -63,7 +95,6 @@
         <% end %>
       </div>
     </div>
-
     <div class="bg-white p-6 rounded-lg shadow-md border border-gray-200">
       <h3 class="text-lg font-medium text-gray-900 mb-4">Spotlight Articles</h3>
       <div class="space-y-4">

--- a/app/views/admin/moderations/_articles_table.html.erb
+++ b/app/views/admin/moderations/_articles_table.html.erb
@@ -3,6 +3,7 @@
     <div class="overflow-visible shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
       <table class="min-w-full divide-y divide-gray-300">
         <thead class="bg-gray-50">
+        <!-- Headers row -->
         <tr>
           <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
             Reported Article & Details
@@ -10,51 +11,51 @@
           <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6 text-right">Actions</th>
         </tr>
         </thead>
+        <!-- Loading each article according to their type i.e. review/reported  -->
+
         <tbody class="divide-y divide-gray-200 bg-white">
         <% articles.each do |article| %>
-          <tr>
+          <% is_review_request = article.moderation_records.any?(&:pending_review?) %>
+
+          <tr id="<%= dom_id(article) %>">
             <td class="py-4 pl-4 pr-3 text-sm sm:pl-6">
               <p class="font-medium text-gray-900"><%= article.title %></p>
-              <p class="text-xs text-gray-500 mt-2">
-                By <%= article.user.name %>
-              </p>
+              <p class="text-xs text-gray-500 mt-1">By <%= article.user.name %></p>
               <div class="mt-2 space-y-1">
-                <% article.reports.pending.each do |report| %>
-                  <p class="text-xs text-gray-500 italic">
-                    "<%= report.reason %>" - <span class="font-semibold"><%= report.user.name %></span>
-                  </p>
+                <% if is_review_request %>
+                  <p class="text-xs text-gray-500 italic">Author's Note: "<%= article.moderation_records.pending_review.last.author_note %>"</p>
+                <% else %>
+                  <% article.reports.pending.each do |report| %>
+                    <p class="text-xs text-gray-500 italic">Reported for: "<%= report.reason %>" - by <%= report.user.name %></p>
+                  <% end %>
                 <% end %>
               </div>
+            </td>
+            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+              <% if is_review_request %>
+                <span class="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10">Awaiting Review</span>
+              <% else %>
+                <span class="inline-flex items-center rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-inset ring-red-700/10">Reported</span>
+              <% end %>
             </td>
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 align-top">
               <div class="flex items-center justify-end gap-x-4">
                 <%= link_to "Show", article_path(article), target: "_blank", class: "text-indigo-600 hover:text-indigo-900" %>
-
-                <div data-controller="dropdown" data-action="click@window->dropdown#hide" class="relative inline-block text-left">
-                  <button data-action="dropdown#toggle" type="button"
-                          class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-                    Actions
-                    <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                      <path fill-rule="evenodd"
-                            d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
-                            clip-rule="evenodd" />
-                    </svg>
-                  </button>
-
-                  <div data-dropdown-target="menu"
-                       class="hidden absolute right-0 z-10 w-48 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none mt-2">
-                    <div class="py-1">
-                      <%= button_to "Mark as Resolved", resolve_reports_admin_article_path(article), method: :patch,
-                                    class: "text-gray-700 block w-full px-4 py-2 text-left text-sm hover:bg-gray-100" %>
-                      <%= button_to "Mark as Dismissed", dismiss_reports_admin_article_path(article), method: :patch,
-                                    class: "text-gray-700 block w-full px-4 py-2 text-left text-sm hover:bg-gray-100" %>
+                <% if is_review_request %>
+                  <%= link_to "Reject", new_rejection_admin_article_path(article), data: { turbo_frame: "_top", turbo_stream: true }, class: "text-sm font-medium text-red-600 hover:text-red-900" %>
+                  <%= button_to "Approve", approve_restoration_admin_article_path(article), method: :patch, class: "text-sm font-medium text-green-600 hover:text-green-900", data: { turbo_frame: "_top", turbo_stream: true} %>
+                <% else %>
+                  <div data-controller="dropdown" data-action="click@window->dropdown#hide" class="relative inline-block text-left">
+                    <button data-dropdown-target="button" data-action="dropdown#toggle" type="button" class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">Actions</button>
+                    <div data-dropdown-target="menu" class="hidden fixed z-10 w-48 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5">
+                      <div class="py-1">
+                        <%= button_to "Resolve Reports", resolve_reports_admin_article_path(article), method: :patch, class: "text-gray-700 block w-full px-4 py-2 text-left text-sm hover:bg-gray-100" %>
+                        <%= button_to "Dismiss Reports", dismiss_reports_admin_article_path(article), method: :patch, class: "text-gray-700 block w-full px-4 py-2 text-left text-sm hover:bg-gray-100" %>
+                      </div>
                     </div>
                   </div>
-                </div>
-
-                <%= link_to "Delete", admin_article_path(article),
-                            data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-                            class: "text-red-600 hover:text-red-900" %>
+                  <%= link_to "Hide", new_hide_admin_article_path(article), class: "text-red-600 hover:text-red-900", data: { turbo_frame: "_top", turbo_stream: true} %>
+                <% end %>
               </div>
             </td>
           </tr>

--- a/app/views/admin/moderations/_hide_article_row.html.erb
+++ b/app/views/admin/moderations/_hide_article_row.html.erb
@@ -1,0 +1,15 @@
+<%= turbo_frame_tag dom_id(article) do %>
+  <tr>
+    <td colspan="3" class="p-0">
+      <%= form_with(model: [:admin, article], url: hide_admin_article_path(article), method: :patch, class: "p-4 bg-gray-50") do |form| %>
+        <h3 class="font-semibold text-gray-900">Hide Article: <%= article.title %></h3>
+        <%= form.label :admin_reason, "Reason for hiding (optional, will be shown to the author):", class: "mt-2 block text-sm font-medium text-gray-700" %>
+        <%= form.text_area :admin_reason, rows: 2, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm" %>
+        <div class="mt-2 flex justify-end gap-x-2">
+          <%= link_to "Cancel", admin_moderation_path(scope: 'articles'), class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50", data: { turbo_frame: "_top"} %>
+          <%= form.submit "Confirm Hide", class: "cursor-pointer rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500", data: {turbo_frame: "_top"} %>
+        </div>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/admin/moderations/_reject_form_row.html.erb
+++ b/app/views/admin/moderations/_reject_form_row.html.erb
@@ -1,0 +1,15 @@
+<%= turbo_frame_tag dom_id(article) do %>
+  <tr>
+    <td colspan="3" class="p-0">
+      <%= form_with(model: [:admin, article], url: reject_restoration_admin_article_path(article), method: :patch, class: "p-4 bg-gray-50") do |form| %>
+        <h3 class="font-semibold text-gray-900">Reject Restoration: <%= article.title %></h3>
+        <%= form.label :rejection_reason, "Reason for rejection (optional, will be shown to the author):", class: "mt-2 block text-sm font-medium text-gray-700" %>
+        <%= form.text_area :rejection_reason, rows: 2, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm" %>
+        <div class="mt-2 flex justify-end gap-x-2">
+          <%= link_to "Cancel", admin_moderation_path(scope: 'articles'), class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50", data: { turbo_frame: "_top"} %>
+          <%= form.submit "Confirm Rejection", class: "cursor-pointer rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500", data: { turbo_frame: "_top"} %>
+        </div>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/admin/moderations/show.html.erb
+++ b/app/views/admin/moderations/show.html.erb
@@ -2,7 +2,7 @@
   <div class="sm:flex sm:items-center mb-6">
     <div class="sm:flex-auto">
       <h1 class="text-2xl font-bold tracking-tight text-gray-900">Content Moderation</h1>
-      <p class="mt-2 text-sm text-gray-700">Review content with pending reports.</p>
+      <p class="mt-2 text-sm text-gray-700">Review content with pending reports or restoration requests.</p>
     </div>
   </div>
 

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,4 +1,15 @@
 <div id="<%= dom_id article %>" class="space-y-5">
+  <!--  Article Hidden details-->
+  <% if article.discarded? %>
+    <div class="p-4 bg-yellow-50 border-l-4 border-yellow-400">
+      <h3 class="font-semibold text-yellow-800">This article is currently hidden.</h3>
+      <% if policy(article).update? %>
+        <p class="text-sm text-yellow-700 mt-1">
+          After saving your changes, this article will be submitted to an administrator for review before it can be restored.
+        </p>
+      <% end %>
+    </div>
+  <% end %>
   <hr class="h-px my-8 bg-gray-200 border-0 dark:bg-gray-700">
   <h1 class="text-4xl sm:text-5xl font-bold tracking-tight leading-tight text-gray-900 mb-6">
     <%= article.title %>

--- a/app/views/articles/_article_card.html.erb
+++ b/app/views/articles/_article_card.html.erb
@@ -25,11 +25,6 @@
                       class: "rounded-md px-3 py-1.5 text-xs text-white bg-red-600 hover:bg-red-500 font-medium",
                       data: { turbo_confirm: "Are you sure?" } %>
       <% end %>
-      <% if policy(article).hide? %>
-        <%= button_to "Hide", hide_article_path(article), method: :patch,
-                      class: "rounded-md px-3 py-1.5 text-xs text-white bg-yellow-600 hover:bg-yellow-500 font-medium",
-                      data: { turbo_confirm: "Are you sure you want to hide this article?" } %>
-      <% end %>
     </div>
   </div>
 

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -15,6 +15,15 @@
       </ul>
     </div>
   <% end %>
+<!--  Article Hidden details-->
+  <% if article.discarded? %>
+    <div class="p-4 bg-yellow-50 border-l-4 border-yellow-400">
+      <h3 class="font-semibold text-yellow-800">This article is currently hidden.</h3>
+      <p class="text-sm text-yellow-700 mt-1">
+        After saving your changes, this article will be submitted to an administrator for review before it can be restored.
+      </p>
+    </div>
+  <% end %>
 
   <!-- Title -->
   <div class="pb-6 border-b border-gray-200">
@@ -59,10 +68,19 @@
          class="prose lg:prose-xl max-w-none min-h-[400px] text-gray-800 focus:outline-none">
     </div>
   </div>
+<!--  Note to admin from author -->
+  <% if article.discarded? %>
+    <div class="pb-6 border-b border-gray-200">
+      <h3 class="text-lg font-medium text-gray-800 mb-2">Note to Admin (Optional)</h3>
+      <p class="text-sm text-gray-500 mb-4">Explain the changes you've made to help the admin review your article.</p>
+      <%= form.text_area :author_note, rows: 3, class: "block w-full rounded-md border-gray-300 shadow-sm", placeholder: "e.g., I've removed the problematic section and clarified my sources." %>
+    </div>
+  <% end %>
 
   <!-- Actions -->
   <div class="flex items-center gap-4 pt-4">
-    <%= form.submit "Publish",
+    <% submit_text = article.discarded? ? "Update & Request Review" : "Publish" %>
+    <%= form.submit submit_text,
                     class: "px-6 py-2.5 rounded-full bg-blue-600 hover:bg-blue-500 text-white font-semibold transition" %>
 
     <% if article.persisted? %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -17,14 +17,6 @@
                     class: "text-sm font-medium text-red-600 hover:text-red-800 transition-colors",
                     data: { turbo_confirm: "Are you sure?" } %>
     <% end %>
-    <% if policy(@article).hide? %>
-      <span class="text-gray-300">|</span>
-
-      <%= button_to "Hide", hide_article_path(@article),
-                    method: :patch,
-                    class: "text-sm font-medium text-yellow-600 hover:text-yellow-800 transition-colors",
-                    data: { turbo_confirm: "Are you sure you want to hide this article?" } %>
-    <% end %>
     <% if policy(Report.new(reportable: @article)).create? %>
       <span class="text-gray-300">|</span>
       <%= link_to "Report this article", new_article_report_path(@article),

--- a/app/views/author_notification_mailer/article_hidden.html.erb
+++ b/app/views/author_notification_mailer/article_hidden.html.erb
@@ -1,0 +1,10 @@
+<h1>Hello, <%= @user.name %></h1>
+<p>
+  Your article, "<%= link_to @article.title, article_url(@article) %>", has been hidden by an administrator.
+</p>
+<% if @record.admin_reason.present? %>
+  <p><strong>Reason provided:</strong> <%= @record.admin_reason %></p>
+<% end %>
+<p>
+  The article is no longer visible to the public, but you can still view and edit it from your profile page. If you make changes to address the issue, you can request a new review.
+</p>

--- a/app/views/author_notification_mailer/request_approved.html.erb
+++ b/app/views/author_notification_mailer/request_approved.html.erb
@@ -1,0 +1,7 @@
+<h1>Great News, <%= @user.name %>!</h1>
+<p>
+  Your restoration request for the article, "<%= link_to @article.title, article_url(@article) %>", has been approved.
+</p>
+<p>
+  The article is now public and visible to all users again.
+</p>

--- a/app/views/author_notification_mailer/request_rejected.html.erb
+++ b/app/views/author_notification_mailer/request_rejected.html.erb
@@ -1,0 +1,10 @@
+<h1>Hello, <%= @user.name %></h1>
+<p>
+  An administrator has reviewed your restoration request for the article, "<%= link_to @article.title, article_url(@article) %>", and it was not approved at this time.
+</p>
+<% if @record.rejection_reason.present? %>
+  <p><strong>Reason provided:</strong> <%= @record.rejection_reason %></p>
+<% end %>
+<p>
+  The article will remain hidden. You are welcome to make further edits and submit another review request from your profile page.
+</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -50,20 +50,39 @@
         <p class="text-gray-600">This user hasn’t published any articles yet.</p>
       </div>
     <% end %>
+<!--  Section for Hidden/Discarded Articles -->
     <% if @discarded_articles.any? && policy(@user).update? %>
       <h2 class="text-2xl font-bold mt-16 mb-6">Hidden Articles</h2>
       <div class="border-t border-gray-200">
         <% @discarded_articles.each do |article| %>
+          <%# Find the latest moderation record for this article %>
+          <% record = article.moderation_records.last %>
           <div class="border-b border-gray-200 py-5">
-            <div class="flex justify-between items-center">
+            <div class="flex justify-between items-start">
               <div>
-                <h3 class="text-lg font-semibold text-gray-500 italic"><%= article.title %></h3>
+                <div class="flex items-center gap-x-3">
+                  <h3 class="text-lg font-semibold text-gray-500 italic"><%= article.title %></h3>
+                  <% if record&.pending_review? %>
+                    <span class="inline-flex items-center rounded-md bg-yellow-50 px-2 py-1 text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20">Pending Review</span>
+                  <% elsif record&.rejected? %>
+                    <span class="inline-flex items-center rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-inset ring-red-700/10">Rejected</span>
+                  <% end %>
+                </div>
                 <p class="text-sm text-gray-400">Hidden on <%= article.discarded_at.strftime("%B %d, %Y") %></p>
+                <% if record %>
+                  <% reason = record.rejected? ? record.rejection_reason : record.admin_reason %>
+                  <% if reason.present? %>
+                    <p class="text-sm text-red-600 mt-2">
+                      Admin Reason: <%= reason %>
+                    </p>
+                  <% end %>
+                <% end %>
               </div>
-              <% if policy(article).restore? %>
-                <%= button_to "Restore", restore_article_path(article), method: :patch,
-                              class: "rounded-md px-3 py-1.5 text-xs bg-green-100 hover:bg-green-200 text-green-800 font-medium" %>
-              <% end %>
+              <div class="flex items-center gap-x-4 flex-shrink-0 ml-4">
+                <% if policy(article).update? %>
+                  <%= link_to "Edit to Request Review", edit_article_path(article), class: "rounded-md px-3 py-1.5 text-xs bg-yellow-100 hover:bg-yellow-200 text-yellow-800 font-medium" %>
+                <% end %>
+              </div>
             </div>
           </div>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,8 @@ Rails.application.routes.draw do
   # article resources
   resources :articles do
     member do
-      patch :restore
-      patch :hide
+      # patch :restore
+      # patch :hide
       post :toggle_clap
     end
     collection do
@@ -52,8 +52,13 @@ Rails.application.routes.draw do
     end
     resources :articles, only: [ :destroy ] do
       member do
+        get :new_hide
+        patch :hide
         patch :resolve_reports
         patch :dismiss_reports
+        patch :approve_restoration
+        get :new_rejection
+        patch :reject_restoration
       end
     end
     # Comments resources

--- a/db/migrate/20250922053808_create_moderation_records.rb
+++ b/db/migrate/20250922053808_create_moderation_records.rb
@@ -1,0 +1,14 @@
+class CreateModerationRecords < ActiveRecord::Migration[8.0]
+  def change
+    create_table :moderation_records do |t|
+      t.references :article, null: false, foreign_key: true
+      t.references :admin, null: false, foreign_key: { to_table: :users }
+      t.text :admin_reason
+      t.text :author_note
+      t.integer :status, default: 0
+
+      t.timestamps
+    end
+    add_index :moderation_records, :status
+  end
+end

--- a/db/migrate/20250922095309_add_rejection_reason_to_moderation_records.rb
+++ b/db/migrate/20250922095309_add_rejection_reason_to_moderation_records.rb
@@ -1,0 +1,5 @@
+class AddRejectionReasonToModerationRecords < ActiveRecord::Migration[8.0]
+  def change
+    add_column :moderation_records, :rejection_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_18_062234) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_22_095309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -104,6 +104,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_062234) do
     t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
   end
 
+  create_table "moderation_records", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.bigint "admin_id", null: false
+    t.text "admin_reason"
+    t.text "author_note"
+    t.integer "status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "rejection_reason"
+    t.index ["admin_id"], name: "index_moderation_records_on_admin_id"
+    t.index ["article_id"], name: "index_moderation_records_on_article_id"
+    t.index ["status"], name: "index_moderation_records_on_status"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "reason"
@@ -159,5 +173,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_062234) do
   add_foreign_key "comments", "articles"
   add_foreign_key "comments", "comments", column: "parent_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "moderation_records", "articles"
+  add_foreign_key "moderation_records", "users", column: "admin_id"
   add_foreign_key "reports", "users"
 end

--- a/spec/factories/moderation_records.rb
+++ b/spec/factories/moderation_records.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :moderation_record do
+    article { nil }
+    admin { nil }
+    admin_reason { "MyText" }
+    author_note { "MyText" }
+    status { 1 }
+  end
+end

--- a/spec/mailers/author_notification_mailer_spec.rb
+++ b/spec/mailers/author_notification_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AuthorNotificationMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/author_notification_mailer_preview.rb
+++ b/spec/mailers/previews/author_notification_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/author_notification_mailer
+class AuthorNotificationMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/models/moderation_record_spec.rb
+++ b/spec/models/moderation_record_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ModerationRecord, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/sidekiq/author_notifier_job_spec.rb
+++ b/spec/sidekiq/author_notifier_job_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+RSpec.describe AuthorNotifierJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# Description

This pull request adds an moderation workflow for articles.  
Admins can hide content with reasons, and authors can request review and restoration.

## Changes

- **ModerationRecord model**
  - Tracks moderation events
  - Fields: admin_reason, author_note, status (hidden, pending_review, approved, rejected)

- **Admin workflow**
  - Admins can hide articles with a reason
  - Moderation queue shows reported + review-pending articles
  - Approve/Reject actions for restoration requests

- **Author workflow**
  - Authors see hidden articles on their profile with admin reason
  - Edit form lets them add a note and request review

- **Authorization**
  - show? allows owners/admins to view hidden articles
  - hide? and restore? restricted to admins

- **Background notifications**
  - AuthorNotificationMailer + AuthorNotifierJob
  - Sidekiq sends emails when an article is hidden, approved, or rejected
